### PR TITLE
Retry tx nonces instead of guarding the nonce with a mutex 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [ ] Response with a meaningul error message if the form is not valid
     - Validate account is not taken (as simple as possible)
     - Public key is a valid Ed25519 key
-- [ ] Retry in case of nonce conflict
+- [x] Retry in case of nonce conflict
 - [ ] (Optional) Protect from spamming
 - [x] Craft a transaction to create the account
 - [x] Sign the transaction with the key of the top-level account


### PR DESCRIPTION
Before this PR we take a mutex that guards the current nonce we want to use while sending a transaction. This works for the most part but it is good to replace it because there are at least two problems with it. One is that it causes unnecessary waiting if multiple people try and create accounts at the same time. Another bigger problem is that we will just fail to create accounts completely if the base account has any transactions sent by someone other than this program. So we can fix it by replacing the `Mutex<Nonce>` with an `AtomicU64` and retrying the transactions if there's a nonce error