### PR TITLE
feat: `contract-helper` feature with the Wallet suitable API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-files"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +440,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic-write-file"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
+dependencies = [
+ "nix",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +508,9 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "blake2"
@@ -705,6 +754,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +802,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +849,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -880,6 +959,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,7 +1025,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -943,6 +1035,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "easy-ext"
@@ -977,6 +1075,9 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1024,6 +1125,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1152,12 @@ name = "fiat-crypto"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+
+[[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "fixed-hash"
@@ -1058,6 +1182,17 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1139,6 +1274,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1268,6 +1414,19 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "heck"
@@ -1283,6 +1442,9 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1297,6 +1459,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1499,6 +1679,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,7 +1738,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -1563,6 +1752,17 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1622,6 +1822,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1861,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1984,6 +2200,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2242,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,6 +2271,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2040,6 +2305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2210,6 +2476,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2616,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,7 +2750,7 @@ checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
  "heck 0.3.3",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -2473,7 +2769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2678,12 +2974,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.12",
+ "libc",
+ "spin 0.9.8",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2721,12 +3052,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+dependencies = [
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2764,6 +3116,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "secp256k1"
@@ -2964,6 +3326,10 @@ name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "siphasher"
@@ -3024,10 +3390,251 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
+dependencies = [
+ "itertools 0.12.1",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba03c279da73694ef99763320dea58b51095dfe87d001b1d4b5fe78ba8763cf"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
+dependencies = [
+ "ahash",
+ "atoi",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "dotenvy",
+ "either",
+ "event-listener",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap 2.2.2",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89961c00dc4d7dffb7aee214964b065072bff69e36ddb9e2c107541f75e4f2a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0bd4519486723648186a08785143599760f7cc81c52334a55d6a83ea1e20841"
+dependencies = [
+ "atomic-write-file",
+ "dotenvy",
+ "either",
+ "heck 0.4.1",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 1.0.109",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.4.2",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.4.2",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "tracing",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "strsim"
@@ -3067,6 +3674,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 name = "sw4-account-creator"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-files",
  "actix-web",
  "anyhow",
@@ -3080,6 +3688,7 @@ dependencies = [
  "near-primitives-core",
  "serde",
  "serde_json",
+ "sqlx",
  "tera",
  "tokio",
  "tracing",
@@ -3698,10 +4307,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3713,6 +4334,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"
@@ -3852,6 +4479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3862,6 +4495,12 @@ dependencies = [
  "once_cell",
  "rustix",
 ]
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+dependencies = [
+ "num-bigint 0.4.4",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2253,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,7 +2314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
- "num-bigint",
+ "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
  "serde",
@@ -3440,6 +3462,7 @@ checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
 dependencies = [
  "ahash",
  "atoi",
+ "bigdecimal",
  "byteorder",
  "bytes",
  "crc",
@@ -3523,6 +3546,7 @@ checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
  "base64 0.21.7",
+ "bigdecimal",
  "bitflags 2.4.2",
  "byteorder",
  "bytes",
@@ -3565,6 +3589,7 @@ checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
  "base64 0.21.7",
+ "bigdecimal",
  "bitflags 2.4.2",
  "byteorder",
  "crc",
@@ -3582,6 +3607,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
+ "num-bigint 0.4.4",
  "once_cell",
  "rand 0.8.5",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+actix-cors = "0.7.0"
 actix-web = "4.4.1"
 actix-files = "0.6.0"
 anyhow = "1.0.79"
@@ -22,13 +23,12 @@ tracing-subscriber = "0.2.16"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 
-actix-cors = "0.7.0"
 sqlx = { version = "0.7.3", features = [
     "runtime-tokio",
     "tls-rustls",
     "postgres",
     "bigdecimal",
-] }
+], optional = true }
 
-# [features]
-# contract-helper = []
+[features]
+contract-helper = ["dep:sqlx"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ sqlx = { version = "0.7.3", features = [
     "runtime-tokio",
     "tls-rustls",
     "postgres",
+    "bigdecimal",
 ] }
 
 # [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,13 @@ tracing = "0.1.28"
 tracing-subscriber = "0.2.16"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
+
+actix-cors = "0.7.0"
+sqlx = { version = "0.7.3", features = [
+    "runtime-tokio",
+    "tls-rustls",
+    "postgres",
+] }
+
+# [features]
+# contract-helper = []

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
     - [x] `GET account/{account_id}/txns` Finds all the transactions for the given account
     - [x] `GET account/{account_id}/likelyTokensFromBlock` Finds all the assets most likely to be [fungible] tokens for the given account from the given block
     - [x] `GET account/{account_id}/likeleNFTsFromBlock` Finds all the assets most likely to be NFTs for the given account from the given block
-    - [ ] `POST account/create` Creates a new account with the given `account_id` and `public_key`
+    - [x] `POST account/create` Creates a new account with the given `account_id` and `public_key`
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@
 - [x] Craft a transaction to create the account
 - [x] Sign the transaction with the key of the top-level account
     - [x] Top-level account and its key are configured in the settings
+- [ ] **Feature** `contract-helper` that provides essential API for the Wallets (similar to the `contract-helper`)
+    - [x] `GET account/keys/{public_key}` Finds all the accounts with the given public key
+    - [x] `GET account/{account_id}/txns` Finds all the transactions for the given account
+    - [x] `GET account/{account_id}/likelyTokensFromBlock` Finds all the assets most likely to be [fungible] tokens for the given account from the given block
+    - [x] `GET account/{account_id}/likeleNFTsFromBlock` Finds all the assets most likely to be NFTs for the given account from the given block
+    - [ ] `POST account/create` Creates a new account with the given `account_id` and `public_key`
 
 ## Configuration
 
@@ -32,6 +38,7 @@ The server is configured using environment variables. The following variables ar
 - `BASE_SIGNER_SECRET_KEY` - Private key of the top-level account
 - `FUNDING_AMOUNT` - Amount of NEAR tokens to fund new accounts with (default 100NEAR)
 - `SERVER_PORT` - Port to listen on (default 10000)
+- [`contract-helper` feature] `DATABASE_URL` - PostgreSQL connection string to the ExplorerDB
 
 ## Getting Started
 

--- a/src/contract_helper/account_activity.rs
+++ b/src/contract_helper/account_activity.rs
@@ -1,0 +1,85 @@
+use actix_web::{web, HttpResponse, Responder, Result};
+use serde::Deserialize;
+use sqlx::PgPool;
+
+// Define a struct to receive the query parameters
+#[derive(Deserialize)]
+pub(crate) struct AccountActivityQuery {
+    order: Option<String>,
+    page: Option<i64>,
+    per_page: Option<i64>,
+}
+
+pub(crate) async fn account_activity_handler(
+    pool: web::Data<PgPool>,
+    account_id: web::Path<String>,
+    web::Query(query_params): web::Query<AccountActivityQuery>,
+) -> Result<impl Responder> {
+    // Set default values if None
+    let order = query_params.order.unwrap_or_else(|| "desc".to_string());
+    let page = query_params.page.unwrap_or(1);
+    let per_page = query_params.per_page.unwrap_or(10);
+
+    // Calculate offset for pagination
+    let offset = (page - 1) * per_page;
+
+    // Ensure 'order' is either 'asc' or 'desc'
+    let order = if order.to_lowercase() == "asc" {
+        "ASC"
+    } else {
+        "DESC"
+    };
+
+    let result: Option<serde_json::Value> = sqlx::query_scalar(
+        &format!( // Use format! to interpolate the 'order' and pagination variables
+            r#"
+            SELECT json_build_object(
+                'txns', json_agg(
+                    json_build_object(
+                        'receipt_id', r.receipt_id,
+                        'predecessor_account_id', r.predecessor_account_id,
+                        'receiver_account_id', r.receiver_account_id,
+                        'transaction_hash', t.transaction_hash,
+                        'included_in_block_hash', b.block_hash,
+                        'block_timestamp', r.included_in_block_timestamp,
+                        'block', json_build_object(
+                            'block_height', b.block_height
+                        ),
+                        'actions', (SELECT json_agg(json_build_object('action', a.action_kind, 'method', a.args->>'method'))
+                                    FROM transaction_actions a
+                                    WHERE a.transaction_hash = t.transaction_hash),
+                        'actions_agg', (SELECT json_build_object('deposit', SUM((a.args->>'deposit')::numeric))
+                                        FROM transaction_actions a
+                                        WHERE a.transaction_hash = t.transaction_hash),
+                        'outcomes', (SELECT json_build_object('status', o.status)
+                                    FROM execution_outcomes o
+                                    WHERE o.receipt_id = t.transaction_hash),
+                        'outcomes_agg', (SELECT json_build_object('transaction_fee', SUM(o.tokens_burnt))
+                                        FROM execution_outcomes o
+                                        WHERE o.receipt_id = t.transaction_hash),
+                        'logs', '[]'::json
+                    ) ORDER BY b.block_height {}
+                )
+            )
+            FROM transactions t
+            JOIN receipts r ON t.converted_into_receipt_id = r.receipt_id
+            JOIN blocks b ON t.included_in_block_hash = b.block_hash
+            WHERE r.predecessor_account_id = $1 OR r.receiver_account_id = $1
+                OFFSET {}
+                LIMIT {}
+            "#, order, offset, per_page
+        )
+    )
+    .bind(&account_id.to_owned())
+    .fetch_optional(&**pool)
+    .await
+    .map_err(|e| {
+        tracing::warn!("Failed to execute query: {:?}", e);
+        HttpResponse::InternalServerError().finish()
+    }).unwrap_or_default();
+
+    match result {
+        Some(json) => Ok(HttpResponse::Ok().json(json)),
+        None => Ok(HttpResponse::Ok().json(serde_json::json!({"txns": []}))),
+    }
+}

--- a/src/contract_helper/account_activity.rs
+++ b/src/contract_helper/account_activity.rs
@@ -20,6 +20,11 @@ pub(crate) async fn account_activity_handler(
     let page = query_params.page.unwrap_or(1);
     let per_page = query_params.per_page.unwrap_or(10);
 
+    tracing::debug!(
+        "account_activity_handler called. account_id: {:?}, order: {:?}, page: {:?}, per_page: {:?}",
+        account_id, order, page, per_page
+    );
+
     // Calculate offset for pagination
     let offset = (page - 1) * per_page;
 

--- a/src/contract_helper/account_by_public_key.rs
+++ b/src/contract_helper/account_by_public_key.rs
@@ -1,0 +1,48 @@
+use actix_web::{web, HttpResponse, Responder, Result};
+use sqlx::PgPool;
+
+pub(crate) async fn account_by_public_key_handler(
+    pool: web::Data<PgPool>,
+    public_key: web::Path<String>,
+) -> Result<impl Responder> {
+    let public_key = public_key.into_inner();
+
+    let result: Option<serde_json::Value> = sqlx::query_scalar(
+        r#"
+        SELECT json_build_object(
+            'keys', json_agg(
+                json_build_object(
+                    'public_key', ak.public_key,
+                    'account_id', acc.account_id,
+                    'permission_kind', ak.permission_kind,
+                    'created', json_build_object(
+                        'transaction_hash', cr.transaction_hash,
+                        'block_timestamp', TO_CHAR(TO_TIMESTAMP(cr.block_timestamp / 1000000000)::timestamp at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS.US')
+                    ),
+                    'deleted', json_build_object(
+                        'transaction_hash', dl.transaction_hash,
+                        'block_timestamp', TO_CHAR(TO_TIMESTAMP(dl.block_timestamp / 1000000000)::timestamp at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS.US')
+                    )
+                )
+            )
+        )
+        FROM access_keys ak
+        LEFT JOIN accounts acc ON ak.account_id = acc.account_id
+        LEFT JOIN transactions cr ON ak.created_by_receipt_id = cr.converted_into_receipt_id
+        LEFT JOIN transactions dl ON ak.deleted_by_receipt_id = dl.converted_into_receipt_id
+        WHERE ak.public_key = $1
+        "#,
+    )
+    .bind(public_key)
+    .fetch_optional(&**pool)
+    .await
+    .map_err(|e| {
+        tracing::warn!("Failed to execute query: {:?}", e);
+        HttpResponse::InternalServerError().finish()
+    }).unwrap_or_default();
+
+    match result {
+        Some(json) => Ok(HttpResponse::Ok().json(json)),
+        None => Ok(HttpResponse::Ok().json(serde_json::json!({"keys": "[]"}))),
+    }
+}

--- a/src/contract_helper/account_by_public_key.rs
+++ b/src/contract_helper/account_by_public_key.rs
@@ -5,6 +5,10 @@ pub(crate) async fn account_by_public_key_handler(
     pool: web::Data<PgPool>,
     public_key: web::Path<String>,
 ) -> Result<impl Responder> {
+    tracing::debug!(
+        "account_by_public_key_handler called. public_key: {:?}",
+        public_key
+    );
     let public_key = public_key.into_inner();
 
     let result: Option<serde_json::Value> = sqlx::query_scalar(

--- a/src/contract_helper/account_create.rs
+++ b/src/contract_helper/account_create.rs
@@ -1,0 +1,84 @@
+use actix_web::{web, HttpResponse, Responder};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct AccountCreateResponse {
+    result: Option<AccountInfo>,
+    error: Option<AccountCreateError>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct AccountInfo {
+    account_id: String,
+    public_key: String,
+}
+
+impl AccountInfo {
+    /// Normalizes the form data by trimming whitespace from the strings
+    fn normalize(self, base_signer_account_id: &str) -> Self {
+        let account_id = self.account_id.trim().to_string();
+        // If account_id provided by the user does not end with .statelessnet, we add it
+        let account_id =
+            if account_id.ends_with(format!(".{}", base_signer_account_id).to_string().as_str()) {
+                account_id
+            } else {
+                format!("{}.{}", account_id, base_signer_account_id)
+            };
+        AccountInfo {
+            account_id,
+            public_key: self.public_key.trim().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct AccountCreateError {
+    message: String,
+}
+
+pub(crate) async fn account_create_handler(
+    data: web::Data<crate::NearData>,
+    account_info: web::Json<AccountInfo>,
+) -> impl Responder {
+    // Extract the account_id and public_key from the request body
+    let normalized_account_info = account_info
+        .clone()
+        .normalize(&data.base_signer.account_id.as_str());
+    let account_id = normalized_account_info.account_id.clone();
+    let public_key = normalized_account_info.public_key.clone();
+
+    // Call the send_account_create function from crate::create_account
+    let result = crate::create_account::send_create_account(
+        &data.rpc,
+        &data.base_signer,
+        &account_id,
+        &public_key,
+        data.nonce.as_ref(),
+        *data.block_hash.read().unwrap(),
+        data.funding_amount,
+    )
+    .await;
+
+    // Return an appropriate response based on the result
+    match result {
+        Ok(_) => {
+            let response = AccountCreateResponse {
+                result: Some(AccountInfo {
+                    account_id: account_id.clone(),
+                    public_key: public_key.clone(),
+                }),
+                error: None,
+            };
+            HttpResponse::Ok().json(response)
+        }
+        Err(err) => {
+            let response = AccountCreateResponse {
+                result: None,
+                error: Some(AccountCreateError {
+                    message: err.to_string(),
+                }),
+            };
+            HttpResponse::InternalServerError().json(response)
+        }
+    }
+}

--- a/src/contract_helper/account_likely_nfts.rs
+++ b/src/contract_helper/account_likely_nfts.rs
@@ -1,0 +1,77 @@
+use actix_web::{web, HttpResponse, Responder, Result};
+use serde::Deserialize;
+use sqlx::PgPool;
+
+#[derive(Deserialize)]
+pub struct AccountLikelyNftsQuery {
+    #[serde(alias = "fromBlockTimestamp")]
+    from_block_timestamp: i64,
+}
+
+pub(crate) async fn account_likely_nfts_handler(
+    pool: web::Data<PgPool>,
+    account_id: web::Path<String>,
+    query_params: web::Query<AccountLikelyNftsQuery>,
+) -> Result<impl Responder> {
+    let account_id = account_id.into_inner();
+    let from_block_timestamp = query_params.into_inner().from_block_timestamp;
+    tracing::debug!(
+        "account_likely_nfts_handler called. account_id: {:?}, from_block_timestamp: {:?}",
+        account_id,
+        from_block_timestamp
+    );
+    // convert from_block_timestamp to BigDecimal
+    let from_block_timestamp = sqlx::types::BigDecimal::from(from_block_timestamp);
+
+    let result: Option<serde_json::Value> = sqlx::query_scalar!(
+        r#"
+        WITH last_block AS (
+            SELECT block_timestamp
+            FROM blocks
+            ORDER BY block_timestamp DESC
+            LIMIT 1
+        ),
+        ownership_change_function_calls AS (
+            SELECT DISTINCT receipt_receiver_account_id AS account_id
+            FROM action_receipt_actions
+            WHERE args->'args_json'->>'receiver_id' = $1
+                AND action_kind = 'FUNCTION_CALL'
+                AND args->>'args_json' IS NOT NULL
+                AND args->>'method_name' LIKE 'nft_%'
+                AND receipt_included_in_block_timestamp <= (SELECT block_timestamp FROM last_block)
+                AND receipt_included_in_block_timestamp > $2
+        ),
+        ownership_change_events AS (
+            SELECT DISTINCT emitted_by_contract_account_id AS account_id
+            FROM assets__non_fungible_token_events
+            WHERE token_new_owner_account_id = $1
+                AND emitted_at_block_timestamp <= (SELECT block_timestamp FROM last_block)
+                AND emitted_at_block_timestamp > $2
+        )
+        SELECT json_build_object(
+            'lastBlockTimestamp', (SELECT block_timestamp FROM last_block)::text,
+            'list', (SELECT array_agg(account_id) FROM (
+                SELECT account_id FROM ownership_change_function_calls
+                UNION
+                SELECT account_id FROM ownership_change_events
+            ) AS combined_results),
+            'version', '1.0.0'
+        ) FROM last_block;
+        "#,
+        account_id,
+        from_block_timestamp
+    )
+    .fetch_optional(&**pool)
+    .await
+    .map_err(|e| {
+        tracing::warn!("Failed to execute query: {:?}", e);
+        HttpResponse::InternalServerError().finish()
+    })
+    .unwrap_or_default()
+    .unwrap_or_default();
+
+    match result {
+        Some(json) => Ok(HttpResponse::Ok().json(json)),
+        None => Ok(HttpResponse::Ok().json(serde_json::json!({"message": "No data found"}))),
+    }
+}

--- a/src/contract_helper/account_likely_tokens.rs
+++ b/src/contract_helper/account_likely_tokens.rs
@@ -1,0 +1,80 @@
+use actix_web::{web, HttpResponse, Responder, Result};
+use serde::Deserialize;
+use sqlx::PgPool;
+
+#[derive(Deserialize)]
+pub struct AccountLikelyTokensQuery {
+    #[serde(alias = "fromBlockTimestamp")]
+    from_block_timestamp: u64,
+}
+
+pub(crate) async fn account_likely_tokens_handler(
+    pool: web::Data<PgPool>,
+    account_id: web::Path<String>,
+    query_params: web::Query<AccountLikelyTokensQuery>,
+) -> Result<impl Responder> {
+    let account_id = account_id.into_inner();
+    let from_block_timestamp = query_params.into_inner().from_block_timestamp;
+    tracing::debug!(
+        "account_likely_tokens_handler called. account_id: {:?}, from_block_timestamp: {:?}",
+        account_id,
+        from_block_timestamp
+    );
+
+    // convert from_block_timestamp to BigDecimal
+    let from_block_timestamp = sqlx::types::BigDecimal::from(from_block_timestamp);
+
+    let result: Option<serde_json::Value> = sqlx::query_scalar!(
+        r#"
+        WITH last_block AS (
+            SELECT block_timestamp
+            FROM blocks
+            ORDER BY block_timestamp DESC
+            LIMIT 1
+        ),
+        received AS (
+            SELECT DISTINCT receipt_receiver_account_id
+            FROM action_receipt_actions
+            WHERE args->'args_json'->>'receiver_id' = $1
+                AND action_kind = 'FUNCTION_CALL'
+                AND args->>'args_json' IS NOT NULL
+                AND args->>'method_name' IN ('ft_transfer', 'ft_transfer_call', 'ft_mint')
+                AND receipt_included_in_block_timestamp <= (SELECT block_timestamp FROM last_block)
+                AND receipt_included_in_block_timestamp > $2
+        ),
+        called_by_user AS (
+            SELECT DISTINCT receipt_receiver_account_id
+            FROM action_receipt_actions
+            WHERE receipt_predecessor_account_id = $1
+                AND action_kind = 'FUNCTION_CALL'
+                AND (args->>'method_name' LIKE 'ft_%' OR args->>'method_name' = 'storage_deposit')
+                AND receipt_included_in_block_timestamp <= (SELECT block_timestamp FROM last_block)
+                AND receipt_included_in_block_timestamp > $2
+        )
+        SELECT json_build_object(
+            'lastBlockTimestamp', (SELECT block_timestamp FROM last_block)::text,
+            'list', (SELECT array_agg(receipt_receiver_account_id) FROM (
+                SELECT receipt_receiver_account_id FROM received
+                UNION
+                SELECT receipt_receiver_account_id FROM called_by_user
+            ) AS combined_results),
+            'version', '1.0.0'
+        ) FROM last_block;
+        "#,
+        account_id,
+        from_block_timestamp,
+    )
+    .fetch_optional(&**pool)
+    .await
+    .map_err(|e| {
+        tracing::warn!("Failed to execute query: {:?}", e);
+        HttpResponse::InternalServerError().finish()
+    })
+    .unwrap_or_default()
+    .unwrap_or_default();
+
+    match result {
+        Some(json) => Ok(HttpResponse::Ok().json(json)),
+        None => Ok(HttpResponse::Ok().json(serde_json::json!({"message": "No data found"}))),
+    }
+}

--- a/src/contract_helper/mod.rs
+++ b/src/contract_helper/mod.rs
@@ -1,7 +1,9 @@
 use actix_web::web;
 
+use account_activity::account_activity_handler;
 use account_by_public_key::account_by_public_key_handler;
 
+mod account_activity;
 mod account_by_public_key;
 
 // Function to create and return the accounts scope
@@ -11,6 +13,10 @@ pub fn account_scope() -> actix_web::Scope {
         .route(
             "/keys/{public_key}",
             web::get().to(account_by_public_key_handler),
+        )
+        .route(
+            "/{account_id}/txns",
+            web::get().to(account_activity_handler),
         )
 }
 

--- a/src/contract_helper/mod.rs
+++ b/src/contract_helper/mod.rs
@@ -2,10 +2,12 @@ use actix_web::web;
 
 use account_activity::account_activity_handler;
 use account_by_public_key::account_by_public_key_handler;
+use account_likely_nfts::account_likely_nfts_handler;
 use account_likely_tokens::account_likely_tokens_handler;
 
 mod account_activity;
 mod account_by_public_key;
+mod account_likely_nfts;
 mod account_likely_tokens;
 
 // Function to create and return the accounts scope
@@ -23,6 +25,10 @@ pub fn account_scope() -> actix_web::Scope {
         .route(
             "/{account_id}/txns",
             web::get().to(account_activity_handler),
+        )
+        .route(
+            "/{account_id}/likelyNFTsFromBlock",
+            web::get().to(account_likely_nfts_handler),
         )
 }
 

--- a/src/contract_helper/mod.rs
+++ b/src/contract_helper/mod.rs
@@ -2,17 +2,23 @@ use actix_web::web;
 
 use account_activity::account_activity_handler;
 use account_by_public_key::account_by_public_key_handler;
+use account_likely_tokens::account_likely_tokens_handler;
 
 mod account_activity;
 mod account_by_public_key;
+mod account_likely_tokens;
 
 // Function to create and return the accounts scope
 pub fn account_scope() -> actix_web::Scope {
-    web::scope("/accounts")
+    web::scope("/account")
         // .route("/create", web::get().to(create_account_handler))
         .route(
             "/keys/{public_key}",
             web::get().to(account_by_public_key_handler),
+        )
+        .route(
+            "/{account_id}/likelyTokensFromBlock",
+            web::get().to(account_likely_tokens_handler),
         )
         .route(
             "/{account_id}/txns",

--- a/src/contract_helper/mod.rs
+++ b/src/contract_helper/mod.rs
@@ -1,0 +1,35 @@
+use actix_web::web;
+
+use account_by_public_key::account_by_public_key_handler;
+
+mod account_by_public_key;
+
+// Function to create and return the accounts scope
+pub fn account_scope() -> actix_web::Scope {
+    web::scope("/accounts")
+        // .route("/create", web::get().to(create_account_handler))
+        .route(
+            "/keys/{public_key}",
+            web::get().to(account_by_public_key_handler),
+        )
+}
+
+// Define the accounts scope as a public constant
+// pub const ACCOUNT_SCOPE: actix_web::Scope = web::scope("/accounts")
+//     // .route("/create", web::get().to(create_account_handler))
+//     .route(
+//         "/keys/{public_key}",
+//         web::get().to(account_by_public_key_handler),
+//     );
+// .route(
+//     "/{account_id}/txns",
+//     web::get().to(account_activity_handler),
+// )
+// .route(
+//     "/{account_id}/likelyTokensFromBlock",
+//     web::put().to(account_likely_tokens_handler),
+// )
+// .route(
+//     "/{account_id}/likelyNFTsFromBlock",
+//     web::delete().to(account_likely_nfts_handler),
+// );

--- a/src/contract_helper/mod.rs
+++ b/src/contract_helper/mod.rs
@@ -2,11 +2,13 @@ use actix_web::web;
 
 use account_activity::account_activity_handler;
 use account_by_public_key::account_by_public_key_handler;
+use account_create::account_create_handler;
 use account_likely_nfts::account_likely_nfts_handler;
 use account_likely_tokens::account_likely_tokens_handler;
 
 mod account_activity;
 mod account_by_public_key;
+mod account_create;
 mod account_likely_nfts;
 mod account_likely_tokens;
 
@@ -30,6 +32,7 @@ pub fn account_scope() -> actix_web::Scope {
             "/{account_id}/likelyNFTsFromBlock",
             web::get().to(account_likely_nfts_handler),
         )
+        .route("/create", web::post().to(account_create_handler))
 }
 
 // Define the accounts scope as a public constant

--- a/src/create_account.rs
+++ b/src/create_account.rs
@@ -1,0 +1,134 @@
+use std::{
+    str::FromStr,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use anyhow::Context;
+use near_account_id::AccountId;
+use near_crypto::{InMemorySigner, PublicKey, Signer};
+use near_jsonrpc_client::{
+    errors::{JsonRpcError, JsonRpcServerError},
+    methods::{self, tx::RpcTransactionError},
+    JsonRpcClient,
+};
+use near_primitives::{
+    account::AccessKey,
+    action::{Action, AddKeyAction, CreateAccountAction, TransferAction},
+    errors::{InvalidTxError, TxExecutionError},
+    hash::CryptoHash,
+    transaction::{SignedTransaction, Transaction},
+    types::Balance,
+    views::FinalExecutionStatus,
+};
+
+use crate::utils::nonce::retry_nonce;
+
+// TODO: rate limit or somehow gate this faucet
+
+/// Creates a Transaction with actions:
+/// - CreateAccount
+/// - AddKey
+/// - Transfer (funding the account)
+/// Signs the transaction by the base signer and sends it to the NEAR RPC node
+pub(crate) async fn send_create_account(
+    near_rpc: &JsonRpcClient,
+    base_signer: &InMemorySigner,
+    account_id: &str,
+    public_key: &str,
+    nonce: &AtomicU64,
+    block_hash: CryptoHash,
+    funding_amount: Balance,
+) -> anyhow::Result<()> {
+    tracing::debug!(
+        "Creating account {} with public key {}",
+        account_id,
+        public_key
+    );
+    let new_account = AccountId::from_str(account_id)
+        .with_context(|| format!("failed parsing account ID: {}", account_id))?;
+    let pkey = PublicKey::from_str(public_key)
+        .with_context(|| format!("failed parsing public key: {}", public_key))?;
+
+    let actions = vec![
+        Action::CreateAccount(CreateAccountAction {}),
+        Action::AddKey(Box::new(AddKeyAction {
+            public_key: pkey,
+            access_key: AccessKey::full_access(),
+        })),
+        Action::Transfer(TransferAction {
+            deposit: funding_amount,
+        }),
+    ];
+    let mut next_nonce = nonce.fetch_add(1, Ordering::SeqCst) + 1;
+
+    loop {
+        let tx = Transaction {
+            signer_id: base_signer.account_id.clone(),
+            public_key: base_signer.public_key.clone(),
+            nonce: next_nonce,
+            receiver_id: new_account.clone(),
+            block_hash,
+            actions: actions.clone(),
+        };
+        let (hash, _size) = tx.get_hash_and_size();
+        let sig = base_signer.sign(hash.as_ref());
+        let signed_transaction = SignedTransaction::new(sig, tx.clone());
+
+        tracing::debug!(
+            "Sending transaction creating {} with nonce {} to NEAR RPC node...",
+            account_id,
+            next_nonce
+        );
+        match near_rpc
+            .call(methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest { signed_transaction })
+            .await
+        {
+            Ok(r) => match r.status {
+                FinalExecutionStatus::SuccessValue(_) => {
+                    tracing::info!(
+                        "transaction execution succeeded for {}: {:?}",
+                        account_id,
+                        &r.status
+                    );
+                    return Ok(());
+                }
+                // looks like this one doesn't show up, and instead we get an Err(JsonRpcError) in this case,
+                // but might as well handle this case here too
+                FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(
+                    InvalidTxError::InvalidNonce { tx_nonce, ak_nonce },
+                )) => {
+                    next_nonce = retry_nonce(nonce, next_nonce, tx_nonce, ak_nonce);
+                    tracing::debug!(
+                        "retrying creating {} with nonce {} after nonce {} was rejected with current access key nonce {}",
+                        account_id,
+                        next_nonce,
+                        tx_nonce,
+                        ak_nonce,
+                    );
+                }
+                _ => {
+                    tracing::warn!("transaction execution failed: {:?}", &r.status);
+                    return Err(anyhow::anyhow!(
+                        "transaction execution failed: {:?}",
+                        &r.status
+                    ));
+                }
+            },
+            Err(JsonRpcError::ServerError(JsonRpcServerError::HandlerError(
+                RpcTransactionError::InvalidTransaction {
+                    context: InvalidTxError::InvalidNonce { tx_nonce, ak_nonce },
+                },
+            ))) => {
+                next_nonce = retry_nonce(nonce, next_nonce, tx_nonce, ak_nonce);
+                tracing::debug!(
+                    "retrying creating {} with nonce {} after nonce {} was rejected with current access key nonce {}",
+                    account_id,
+                    next_nonce,
+                    tx_nonce,
+                    ak_nonce,
+                );
+            }
+            Err(e) => return Err(e.into()),
+        };
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use serde::Deserialize;
 use tera::{Context, Tera};
 use tracing_subscriber::EnvFilter;
 
+#[cfg(feature = "contract-helper")]
 mod contract_helper;
 
 // ======== STRUCTURES ========
@@ -50,6 +51,7 @@ struct Args {
     /// Amount to fund new accounts with, default 100 NEAR
     #[clap(long, env, default_value_t = 100_000_000_000_000_000_000_000_000)]
     funding_amount: Balance,
+    #[cfg(feature = "contract-helper")]
     /// ExplorerDB connection string to fetch the data for contract-helper feature
     #[clap(long, env)]
     database_url: String,
@@ -353,6 +355,7 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let tera = Tera::new("templates/**/*").unwrap();
 
+    #[cfg(feature = "contract-helper")]
     let pool = sqlx::PgPool::connect(&args.database_url).await?;
 
     tracing::debug!("Parsing base signer account ID and secret key...");
@@ -410,15 +413,23 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("Starting the HTTP server on port {}...", args.server_port);
 
     HttpServer::new(move || {
-        App::new()
+        #[allow(unused_mut)]
+        let mut app = App::new()
             .wrap(actix_cors::Cors::permissive())
             .app_data(web::Data::new(tera.clone()))
             .app_data(web::Data::new(near_data.clone()))
-            .app_data(web::Data::new(pool.clone()))
-            .service(contract_helper::account_scope())
             .service(fs::Files::new("/assets", "assets").show_files_listing()) // for serving the static files
             .route("/", web::get().to(index))
-            .route("/create_account", web::post().to(create_account))
+            .route("/create_account", web::post().to(create_account));
+
+        #[cfg(feature = "contract-helper")]
+        {
+            app = app
+                .app_data(web::Data::new(pool.clone()))
+                .service(contract_helper::account_scope());
+        }
+
+        app
     })
     .bind(format!("0.0.0.0:{:0>5}", args.server_port))?
     .run()

--- a/src/utils/block_hash.rs
+++ b/src/utils/block_hash.rs
@@ -1,0 +1,44 @@
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use near_jsonrpc_client::{
+    errors::JsonRpcError,
+    methods::status::{RpcStatusError, RpcStatusRequest},
+    JsonRpcClient,
+};
+use near_primitives::hash::CryptoHash;
+
+/// Fetches the current block hash from the NEAR RPC node
+pub(crate) async fn current_block_hash(
+    near_rpc: &JsonRpcClient,
+) -> Result<CryptoHash, JsonRpcError<RpcStatusError>> {
+    tracing::debug!("Fetching current block hash from NEAR RPC node...");
+    near_rpc
+        .call(RpcStatusRequest)
+        .await
+        .map(|status| status.sync_info.latest_block_hash)
+}
+
+/// Constantly updates the block hash in the given `Arc<RwLock<CryptoHash>>` every 30 seconds
+/// by fetching the latest block hash from the NEAR RPC node
+/// This is used to ensure that the block hash used in the transaction is always up to date
+pub(crate) async fn update_block_hash(
+    near_rpc: JsonRpcClient,
+    block_hash: Arc<RwLock<CryptoHash>>,
+) {
+    loop {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        tracing::debug!("Updating block hash...");
+        let current = match current_block_hash(&near_rpc).await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!("failed to fetch current block hash: {:?}", e);
+                continue;
+            }
+        };
+        let mut b = block_hash.write().unwrap();
+        *b = current;
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod block_hash;
+pub(crate) mod nonce;

--- a/src/utils/nonce.rs
+++ b/src/utils/nonce.rs
@@ -1,0 +1,30 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use near_primitives::types::Nonce;
+
+/// Returns a nonce greater than both the nonces we know are too small.
+fn new_nonce(nonce1: Nonce, nonce2: Nonce) -> Nonce {
+    std::cmp::max(nonce1, nonce2) + 1
+}
+
+/// Returns and stores in `nonce` a new nonce to try with after getting an InvalidNonce{ tx_nonce, ak_nonce } error
+pub(crate) fn retry_nonce(
+    nonce: &AtomicU64,
+    old_nonce: Nonce,
+    tx_nonce: Nonce,
+    ak_nonce: Nonce,
+) -> Nonce {
+    if tx_nonce != old_nonce {
+        tracing::warn!(
+            "NEAR RPC node reported that our transaction's nonce was {}, when we remember sending {}",
+            tx_nonce, old_nonce
+        );
+    }
+    let prev_nonce = nonce
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
+            Some(new_nonce(n, ak_nonce))
+        })
+        .unwrap();
+    // now we call new_nonce() again because fetch_update() returns the old value
+    new_nonce(prev_nonce, ak_nonce)
+}


### PR DESCRIPTION
I am sorry this PR is a bit huge. 

We asked the community to help us enable Wallet for StatelessNet (Stake Wars IV), and they provided us with the list of necessary API endpoints for a Wallet to work. Formerly, an API like this was supplied by Pagoda (named `contract-helper`). Today, the situation is a bit different, and the community has improved the API compared to the historical `contract-helper`. Nevertheless, I am too old to remember it, so I've introduced a feature in an old friend's name to enable the Wallet's APIs.

### `contract-helper` feature 

In this PR, I introduce the feature `contract-helper` (disabled by default). This feature enables a set of API endpoints under the `/account` path:

* `/account/create` to create an account like initially with `sw4-account-creator` but using JSON
* `/keys/{public_key}` to find all the accounts with the given key added
* `/{account_id}/txns` to fetch the given account's activity
* `/{account_id}/likelyTokensFromBlock` to retrieve all the assets likely to be fungible tokens (I am unsure it would properly work on `statelessnet`, though)
* `/account_id}/likelyNFTsFromBlock` similar to the fungible tokens, but for NFTs. Again, it's going to fail to work correctly.

*Footnote*: When I say "I am unsure it's going to work properly", I mean that `statelessnet` doesn't aim to have everything mainnet or testnet already has. I refer to the fact that no one is focused on bringing all the FT/NFT contracts to live on this network. However, those methods are expected to respond with the correct data if someone did it. Please open an issue if you have some.

### Other changes

In addition, I moved some of the code from `main.rs` to separate modules since the codebase grew a bit. Everything is tested manually, and everything works as expected.

P.S.: I will deploy this version immediately, along with the improvement from #2, before the PR review is completed since this project has low stakes.